### PR TITLE
Refresh S3 expiration on get.

### DIFF
--- a/internal/cache/s3/BUILD.bazel
+++ b/internal/cache/s3/BUILD.bazel
@@ -12,5 +12,6 @@ go_library(
         "@com_github_aws_aws_sdk_go//service/s3:go_default_library",
         "@com_github_aws_aws_sdk_go//service/s3/s3manager:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_zenreach_hatchet//:go_default_library",
     ],
 )

--- a/internal/cache/s3/s3.go
+++ b/internal/cache/s3/s3.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/pkg/errors"
+	"github.com/zenreach/hatchet"
 	"github.com/zenreach/hydroponics/internal/cache"
 )
 
@@ -21,6 +24,8 @@ type Cache struct {
 	clean    *regexp.Regexp
 	bucket   string
 	prefix   string
+	logger   hatchet.Logger
+	wg       *sync.WaitGroup
 }
 
 // New returns a new S3 cache which stores objects in the bucket with the given
@@ -30,7 +35,7 @@ type Cache struct {
 // underscores, and dashes are allowed. All other characters are replaced by
 // underscores. Ensure keys match this pattern in order to avoid collisions due
 // to the sanitization.
-func New(bucket, prefix string) (*Cache, error) {
+func New(bucket, prefix string, logger hatchet.Logger) (*Cache, error) {
 	sesh, err := session.NewSession()
 	if err != nil {
 		return nil, errors.Wrap(err, "aws client")
@@ -46,13 +51,15 @@ func New(bucket, prefix string) (*Cache, error) {
 		clean:    regexp.MustCompile(`[^a-zA-Z0-9_-]`),
 		bucket:   bucket,
 		prefix:   prefix,
+		logger:   logger,
+		wg:       &sync.WaitGroup{},
 	}, nil
 }
 
 func (c *Cache) realKey(key string) string {
 	key = c.clean.ReplaceAllString(key, "_")
 	if c.prefix != "" {
-		key = fmt.Sprintf("%s/%s", c.prefix, key)
+		key = fmt.Sprintf("%s%s", c.prefix, key)
 	}
 	return key
 }
@@ -70,6 +77,7 @@ func (c *Cache) Get(ctx context.Context, key string) (io.ReadCloser, error) {
 		}
 		return nil, errors.Wrap(err, "aws client")
 	}
+	c.touch(key)
 	return res.Body, nil
 }
 
@@ -83,6 +91,65 @@ func (c *Cache) Put(ctx context.Context, key string, data io.Reader) error {
 		return err
 	}
 	return errors.Wrap(err, "aws client")
+}
+
+func (c *Cache) Shutdown(ctx context.Context) error {
+	ch := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(ch)
+	}()
+
+	select {
+	case <-ch:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
+}
+
+func (c *Cache) touch(key string) {
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		realKey := c.realKey(key)
+		source := fmt.Sprintf("/%s/%s", c.bucket, realKey)
+		_, err := c.client.CopyObject(&s3.CopyObjectInput{
+			Bucket:     sp(c.bucket),
+			Key:        sp(realKey),
+			CopySource: sp(source),
+			Metadata: map[string]*string{
+				"refreshed": sp(fmt.Sprintf("%d", time.Now().UTC().Unix())),
+			},
+			MetadataDirective: sp("REPLACE"),
+		})
+		if err == nil {
+			c.logDebug(realKey, source, "refresh key")
+		} else {
+			c.logError(err, realKey, source, "key refresh error")
+		}
+	}()
+}
+
+func (c *Cache) logError(err error, key, source, msg string) {
+	c.logger.Log(hatchet.L{
+		"message": msg,
+		"bucket":  c.bucket,
+		"key":     key,
+		"source":  source,
+		"level":   "error",
+		"error":   err,
+	})
+}
+
+func (c *Cache) logDebug(key, source, msg string) {
+	c.logger.Log(hatchet.L{
+		"message": msg,
+		"bucket":  c.bucket,
+		"key":     key,
+		"source":  source,
+		"level":   "debug",
+	})
 }
 
 func sp(s string) *string {


### PR DESCRIPTION
At present S3 removes cached items at a fixed time after upload. This causes the cache to invalidate items even if they're in heavy use.

This PR allows S3 to work more like an LRU cache. Each time an object is retrieved it is copied in order to have its expiration reset.