### PR TITLE
Fix cache miss error check in head call.

### DIFF
--- a/internal/cache/s3/s3.go
+++ b/internal/cache/s3/s3.go
@@ -78,9 +78,10 @@ func (c *Cache) Get(ctx context.Context, key string) (io.ReadCloser, error) {
 		Bucket: sp(c.bucket),
 		Key:    sp(realKey),
 	})
-	if isErrCode(err, s3.ErrCodeNoSuchKey) {
+	if isErrCode(err, 404) {
 		return nil, cache.ErrCacheMiss
 	} else if err != nil {
+		fmt.Printf("%#v\n", err)
 		if err == ctx.Err() {
 			return nil, err
 		}
@@ -202,10 +203,10 @@ func sp(s string) *string {
 	return &s
 }
 
-func isErrCode(err error, code string) bool {
-	awsErr, ok := err.(awserr.Error)
+func isErrCode(err error, code int) bool {
+	awsErr, ok := err.(awserr.RequestFailure)
 	if !ok {
 		return false
 	}
-	return awsErr.Code() == code
+	return awsErr.StatusCode() == code
 }


### PR DESCRIPTION
The error check is different for calls to `HeadObject` than for `GetObject` so this PR makes that change.

Prior to this change, a missing object resulted in a 500 (internal error) instead of a 404 (cache miss).